### PR TITLE
Update the import paths, now 'go get' should work

### DIFF
--- a/api_deploys.go
+++ b/api_deploys.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Deploy(body *dtos.SingularityDeployRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_deploys_deploy_deployId_request_requestId.go
+++ b/api_deploys_deploy_deployId_request_requestId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) CancelDeploy(requestId string, deployId string) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_deploys_pending.go
+++ b/api_deploys_pending.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetPendingDeploys() (response dtos.SingularityPendingDeployList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_deploys_update.go
+++ b/api_deploys_update.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) UpdatePendingDeploy(body *dtos.SingularityUpdatePendingDeployRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_history_request_requestId_deploy_deployId.go
+++ b/api_history_request_requestId_deploy_deployId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getDeploy(requestId string, deployId string) (response *dtos.SingularityDeployHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_request_requestId_deploy_deployId_tasks_active.go
+++ b/api_history_request_requestId_deploy_deployId_tasks_active.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getActiveDeployTasks(requestId string, deployId string) (response *dtos.SingularityTaskIdHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_request_requestId_deploy_deployId_tasks_inactive.go
+++ b/api_history_request_requestId_deploy_deployId_tasks_inactive.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getInactiveDeployTasks(requestId string, deployId string, count int32, page int32) (response *dtos.SingularityTaskIdHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_request_requestId_deploys.go
+++ b/api_history_request_requestId_deploys.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getDeploys(requestId string, count int32, page int32) (response *dtos.SingularityDeployHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_request_requestId_requests.go
+++ b/api_history_request_requestId_requests.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getRequestHistoryForRequest(requestId string, count int32, page int32) (response *dtos.SingularityRequestHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_request_requestId_run_runId.go
+++ b/api_history_request_requestId_run_runId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getTaskHistoryForRequest(requestId string, runId string) (response *dtos.SingularityTaskIdHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_history_task_taskId.go
+++ b/api_history_task_taskId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getHistoryForTask(taskId string) (response *dtos.SingularityTaskHistory, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_racks_.go
+++ b/api_racks_.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetRacks(state string) (response dtos.SingularityRackList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_racks_rack_rackId.go
+++ b/api_racks_rack_rackId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetRackHistory(rackId string) (response dtos.SingularityMachineStateHistoryUpdateList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_racks_rack_rackId_activate.go
+++ b/api_racks_rack_rackId_activate.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) ActivateSlave(rackId string, body *dtos.SingularityMachineChangeRequest) (err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_racks_rack_rackId_decommission.go
+++ b/api_racks_rack_rackId_decommission.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) DecommissionRack(rackId string, body *dtos.SingularityMachineChangeRequest) (err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_racks_rack_rackId_freeze.go
+++ b/api_racks_rack_rackId_freeze.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) FreezeRack(rackId string, body *dtos.SingularityMachineChangeRequest) (err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests.go
+++ b/api_requests.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetRequests() (response dtos.SingularityRequestParentList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_active.go
+++ b/api_requests_active.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetActiveRequests() (response dtos.SingularityRequestParentList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_cooldown.go
+++ b/api_requests_cooldown.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetCooldownRequests() (response dtos.SingularityRequestParentList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_finished.go
+++ b/api_requests_finished.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetFinishedRequests() (response dtos.SingularityRequestParentList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_lbcleanup.go
+++ b/api_requests_lbcleanup.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetLbCleanupRequests() (response dtos.StringList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_paused.go
+++ b/api_requests_paused.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetPausedRequests() (response dtos.SingularityRequestParentList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_queued_cleanup.go
+++ b/api_requests_queued_cleanup.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetCleanupRequests() (response dtos.SingularityRequestCleanupList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_queued_pending.go
+++ b/api_requests_queued_pending.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetPendingRequests() (response dtos.SingularityPendingRequestList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_requests_request_requestId.go
+++ b/api_requests_request_requestId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetRequest(requestId string) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_bounce.go
+++ b/api_requests_request_requestId_bounce.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Bounce(requestId string, body *dtos.SingularityBounceRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_exit-cooldown.go
+++ b/api_requests_request_requestId_exit-cooldown.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) ExitCooldown(requestId string, body *dtos.SingularityExitCooldownRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_pause.go
+++ b/api_requests_request_requestId_pause.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Pause(requestId string, body *dtos.SingularityPauseRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_run.go
+++ b/api_requests_request_requestId_run.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) ScheduleImmediately(requestId string, body *dtos.SingularityRunNowRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_scale.go
+++ b/api_requests_request_requestId_scale.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Scale(requestId string, body *dtos.SingularityScaleRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_skipHealthchecks.go
+++ b/api_requests_request_requestId_skipHealthchecks.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) SkipHealthchecks(requestId string, body *dtos.SingularitySkipHealthchecksRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_requests_request_requestId_unpause.go
+++ b/api_requests_request_requestId_unpause.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Unpause(requestId string, body *dtos.SingularityUnpauseRequest) (response *dtos.SingularityRequestParent, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_sandbox_taskId_browse.go
+++ b/api_sandbox_taskId_browse.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Browse(taskId string, path string) (response *dtos.SingularitySandbox, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_sandbox_taskId_read.go
+++ b/api_sandbox_taskId_read.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) Read(taskId string, path string, grep string, offset int64, length int64) (response *dtos.MesosFileChunkObject, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_slaves_.go
+++ b/api_slaves_.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getSlaves(state string) (response *dtos.SingularitySlave, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_slaves_slave_slaveId.go
+++ b/api_slaves_slave_slaveId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) getSlaveHistory(slaveId string) (response *dtos.SingularityMachineStateHistoryUpdate, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_slaves_slave_slaveId_decommission.go
+++ b/api_slaves_slave_slaveId_decommission.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) decommissionSlave(slaveId string, body *dtos.SingularityMachineChangeRequest) (err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_slaves_slave_slaveId_freeze.go
+++ b/api_slaves_slave_slaveId_freeze.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) freezeSlave(slaveId string, body *dtos.SingularityMachineChangeRequest) (err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_state.go
+++ b/api_state.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetState(skipCache bool, includeRequestIds bool) (response *dtos.SingularityState, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_state_requests_over-provisioned.go
+++ b/api_state_requests_over-provisioned.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetOverProvisionedRequestIds(skipCache bool) (response dtos.StringList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_state_requests_under-provisioned.go
+++ b/api_state_requests_under-provisioned.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetUnderProvisionedRequestIds(skipCache bool) (response dtos.StringList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_active.go
+++ b/api_tasks_active.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetActiveTasks() (response dtos.SingularityTaskList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_active_slave_slaveId.go
+++ b/api_tasks_active_slave_slaveId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetTasksForSlave(slaveId string) (response dtos.SingularityTaskList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_cleaning.go
+++ b/api_tasks_cleaning.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetCleaningTasks() (response dtos.SingularityTaskCleanupList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_killed.go
+++ b/api_tasks_killed.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetKilledTasks() (response dtos.SingularityKilledTaskIdRecordList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_lbcleanup.go
+++ b/api_tasks_lbcleanup.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetLbCleanupTasks() (response dtos.SingularityTaskIdList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_scheduled.go
+++ b/api_tasks_scheduled.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetScheduledTasks() (response dtos.SingularityTaskRequestList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_scheduled_ids.go
+++ b/api_tasks_scheduled_ids.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetScheduledTaskIds() (response dtos.SingularityPendingTaskIdList, err error) {
 	pathParamMap := map[string]interface{}{}

--- a/api_tasks_scheduled_request_requestId.go
+++ b/api_tasks_scheduled_request_requestId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetScheduledTasksForRequest(requestId string) (response dtos.SingularityTaskRequestList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_scheduled_task_pendingTaskId.go
+++ b/api_tasks_scheduled_task_pendingTaskId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetPendingTask(pendingTaskId string) (response *dtos.SingularityTaskRequest, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_task_taskId.go
+++ b/api_tasks_task_taskId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) KillTask(taskId string, body *dtos.SingularityKillTaskRequest) (response *dtos.SingularityTaskCleanup, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_task_taskId_cleanup.go
+++ b/api_tasks_task_taskId_cleanup.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetTaskCleanup(taskId string) (response *dtos.SingularityTaskCleanup, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_task_taskId_command.go
+++ b/api_tasks_task_taskId_command.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) RunShellCommand(taskId string, body *dtos.SingularityShellCommand) (response *dtos.SingularityTaskShellCommandRequest, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_tasks_task_taskId_statistics.go
+++ b/api_tasks_task_taskId_statistics.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetTaskStatistics(taskId string) (response *dtos.MesosTaskStatisticsObject, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_webhooks.go
+++ b/api_webhooks.go
@@ -3,7 +3,7 @@ package client
 import (
 	"bytes"
 
-	"github.com/opentable/sous-singularity/client/dtos"
+	"github.com/opentable/singularity/dtos"
 )
 
 func (client *Client) GetActiveWebhooks() (response dtos.SingularityWebhookList, err error) {

--- a/api_webhooks_deploy_webhookId.go
+++ b/api_webhooks_deploy_webhookId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetQueuedDeployUpdates(webhookId string) (response dtos.SingularityDeployUpdateList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_webhooks_request_webhookId.go
+++ b/api_webhooks_request_webhookId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetQueuedRequestUpdates(webhookId string) (response dtos.SingularityRequestHistoryList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/api_webhooks_task_webhookId.go
+++ b/api_webhooks_task_webhookId.go
@@ -1,6 +1,6 @@
 package client
 
-import "github.com/opentable/sous-singularity/client/dtos"
+import "github.com/opentable/singularity/dtos"
 
 func (client *Client) GetQueuedTaskUpdates(webhookId string) (response dtos.SingularityTaskHistoryUpdateList, err error) {
 	pathParamMap := map[string]interface{}{

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/opentable/sous-singularity/client/dtos"
+	"github.com/opentable/singularity/dtos"
 )
 
 type Client struct {

--- a/test/main.go
+++ b/test/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/opentable/sous-singularity/client"
-	"github.com/opentable/sous-singularity/client/dtos"
+	"github.com/opentable/singularity/client"
+	"github.com/opentable/singularity/dtos"
 )
 
 func dockerMachine(args ...string) (stdoutStr, stderrStr string, err error) {


### PR DESCRIPTION
I just noticed when running `go get github.com/opentable/singularity` that the build wasn't working due to the import paths pointing at other dirs.

I would recommend deleting the old `sous-singularity` directory on your dev machine after pulling this, to make sure `goimports` never gets confused.
